### PR TITLE
Consolidate ban functions (old version; just in case)

### DIFF
--- a/doc/release-notes-19825.md
+++ b/doc/release-notes-19825.md
@@ -1,0 +1,2 @@
+### RPC and other APIs
+- #19825 `setban` behavior changed. Banning a subnet that is a subset of a previous ban for a shorter duration is a no-op. Banning a subnet that is a superset of a previous ban for a longer duration will result in ban entry consolidation.

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -76,21 +76,6 @@ bool BanMan::IsDiscouraged(const CNetAddr& net_addr)
     return m_discouraged.contains(net_addr.GetAddrBytes());
 }
 
-bool BanMan::IsBanned(const CNetAddr& net_addr)
-{
-    auto current_time = GetTime();
-    LOCK(m_cs_banned);
-    for (const auto& it : m_banned) {
-        CSubNet sub_net = it.first;
-        CBanEntry ban_entry = it.second;
-
-        if (current_time < ban_entry.nBanUntil && sub_net.Match(net_addr)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 bool BanMan::HasBannedAddresses(const CSubNet& sub_net)
 {
     auto current_time = GetTime();

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -142,12 +142,6 @@ bool BanMan::Ban(const CSubNet& sub_net, int64_t ban_time_offset, bool since_uni
     return true;
 }
 
-bool BanMan::Unban(const CNetAddr& net_addr)
-{
-    CSubNet sub_net(net_addr);
-    return Unban(sub_net);
-}
-
 bool BanMan::Unban(const CSubNet& sub_net)
 {
     {

--- a/src/banman.h
+++ b/src/banman.h
@@ -65,9 +65,6 @@ public:
     void Discourage(const CNetAddr& net_addr);
     void ClearBanned();
 
-    //! Return whether net_addr is banned
-    bool IsBanned(const CNetAddr& net_addr);
-
     //! Return true if subnet includes previously banned addresses
     bool HasBannedAddresses(const CSubNet& sub_net);
 

--- a/src/banman.h
+++ b/src/banman.h
@@ -59,16 +59,17 @@ class BanMan
 public:
     ~BanMan();
     BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time);
-    void Ban(const CNetAddr& net_addr, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
-    void Ban(const CSubNet& sub_net, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
+
+    //! Returns true if a new ban is added
+    bool Ban(const CSubNet& sub_net, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
     void Discourage(const CNetAddr& net_addr);
     void ClearBanned();
 
     //! Return whether net_addr is banned
     bool IsBanned(const CNetAddr& net_addr);
 
-    //! Return whether sub_net is exactly banned
-    bool IsBanned(const CSubNet& sub_net);
+    //! Return true if subnet includes previously banned addresses
+    bool HasBannedAddresses(const CSubNet& sub_net);
 
     //! Return whether net_addr is discouraged.
     bool IsDiscouraged(const CNetAddr& net_addr);

--- a/src/banman.h
+++ b/src/banman.h
@@ -71,7 +71,6 @@ public:
     //! Return whether net_addr is discouraged.
     bool IsDiscouraged(const CNetAddr& net_addr);
 
-    bool Unban(const CNetAddr& net_addr);
     bool Unban(const CSubNet& sub_net);
     void GetBanned(banmap_t& banmap);
     void DumpBanlist();

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -133,10 +133,10 @@ public:
         }
         return false;
     }
-    bool ban(const CNetAddr& net_addr, int64_t ban_time_offset) override
+    bool ban(const CSubNet& sub_net, int64_t ban_time_offset) override
     {
         if (m_context->banman) {
-            m_context->banman->Ban(net_addr, ban_time_offset);
+            m_context->banman->Ban(sub_net, ban_time_offset);
             return true;
         }
         return false;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -99,7 +99,7 @@ public:
     virtual bool getBanned(banmap_t& banmap) = 0;
 
     //! Ban node.
-    virtual bool ban(const CNetAddr& net_addr, int64_t ban_time_offset) = 0;
+    virtual bool ban(const CSubNet& net_addr, int64_t ban_time_offset) = 0;
 
     //! Unban node.
     virtual bool unban(const CSubNet& ip) = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1017,7 +1017,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     SetSocketNoDelay(hSocket);
 
     // Don't accept connections from banned peers.
-    bool banned = m_banman && m_banman->IsBanned(addr);
+    bool banned = m_banman && m_banman->HasBannedAddresses(CSubNet(addr));
     if (!NetPermissions::HasFlag(permissionFlags, NetPermissionFlags::PF_NOBAN) && banned)
     {
         LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
@@ -2062,7 +2062,7 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
         return;
     }
     if (!pszDest) {
-        bool banned_or_discouraged = m_banman && (m_banman->IsDiscouraged(addrConnect) || m_banman->IsBanned(addrConnect));
+        bool banned_or_discouraged = m_banman && (m_banman->IsDiscouraged(addrConnect) || m_banman->HasBannedAddresses(CSubNet(addrConnect)));
         if (IsLocal(addrConnect) || FindNode(static_cast<CNetAddr>(addrConnect)) || banned_or_discouraged || FindNode(addrConnect.ToStringIPPort())) {
             return;
         }
@@ -2533,7 +2533,7 @@ std::vector<CAddress> CConnman::GetAddresses(size_t max_addresses, size_t max_pc
     std::vector<CAddress> addresses = addrman.GetAddr(max_addresses, max_pct);
     if (m_banman) {
         addresses.erase(std::remove_if(addresses.begin(), addresses.end(),
-                        [this](const CAddress& addr){return m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr);}),
+                        [this](const CAddress& addr){return m_banman->IsDiscouraged(addr) || m_banman->HasBannedAddresses(CSubNet(addr));}),
                         addresses.end());
     }
     return addresses;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2582,7 +2582,7 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)
                 addr.nTime = nNow - 5 * 24 * 60 * 60;
             pfrom.AddAddressKnown(addr);
-            if (m_banman && (m_banman->IsDiscouraged(addr) || m_banman->IsBanned(addr))) {
+            if (m_banman && (m_banman->IsDiscouraged(addr) || m_banman->HasBannedAddresses(CSubNet(addr)))) {
                 // Do not process banned/discouraged addresses beyond remembering we received them
                 continue;
             }

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -170,6 +170,9 @@ class CNetAddr
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);
         friend bool operator!=(const CNetAddr& a, const CNetAddr& b) { return !(a == b); }
         friend bool operator<(const CNetAddr& a, const CNetAddr& b);
+        friend bool operator>=(const CNetAddr& a, const CNetAddr& b) { return !(a < b); }
+        friend bool operator>(const CNetAddr& a, const CNetAddr& b) { return (a >= b) && (a != b); }
+        friend bool operator<=(const CNetAddr& a, const CNetAddr& b) { return !(a > b); }
 
         /**
          * Serialize to a stream.
@@ -294,6 +297,9 @@ class CSubNet
 
         bool Match(const CNetAddr &addr) const;
 
+        // Returns whether this subnet is a superset of otherSubnet
+        bool IsSuperset(const CSubNet& otherSubnet) const;
+
         std::string ToString() const;
         bool IsValid() const;
 
@@ -302,6 +308,10 @@ class CSubNet
         friend bool operator<(const CSubNet& a, const CSubNet& b);
 
         SERIALIZE_METHODS(CSubNet, obj) { READWRITE(obj.network, obj.netmask, obj.valid); }
+
+    private:
+        const CNetAddr MinAddress() const;
+        const CNetAddr MaxAddress() const;
 };
 
 /** A combination of a network address (CNetAddr) and a (TCP) port */

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1223,7 +1223,8 @@ void RPCConsole::banSelectedNode(int bantime)
         // Find possible nodes, ban it and clear the selected node
         const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(detailNodeRow);
         if (stats) {
-            m_node.ban(stats->nodeStats.addr, bantime);
+            CSubNet sub_net(stats->nodeStats.addr);
+            m_node.ban(sub_net, bantime);
             m_node.disconnectByAddress(stats->nodeStats.addr);
         }
     }

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -37,12 +37,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     {
         BanMan ban_man{banlist_file, nullptr, ConsumeBanTimeOffset(fuzzed_data_provider)};
         while (fuzzed_data_provider.ConsumeBool()) {
-            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 11)) {
-            case 0: {
-                ban_man.Ban(ConsumeNetAddr(fuzzed_data_provider),
-                    ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
-                break;
-            }
+            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(1, 11)) {
             case 1: {
                 ban_man.Ban(ConsumeSubNet(fuzzed_data_provider),
                     ConsumeBanTimeOffset(fuzzed_data_provider), fuzzed_data_provider.ConsumeBool());
@@ -57,7 +52,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 break;
             }
             case 5: {
-                ban_man.IsBanned(ConsumeSubNet(fuzzed_data_provider));
+                ban_man.HasBannedAddresses(ConsumeSubNet(fuzzed_data_provider));
                 break;
             }
             case 6: {

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -47,10 +47,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 ban_man.ClearBanned();
                 break;
             }
-            case 4: {
-                ban_man.IsBanned(ConsumeNetAddr(fuzzed_data_provider));
-                break;
-            }
             case 5: {
                 ban_man.HasBannedAddresses(ConsumeSubNet(fuzzed_data_provider));
                 break;

--- a/src/test/fuzz/banman.cpp
+++ b/src/test/fuzz/banman.cpp
@@ -51,10 +51,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 ban_man.HasBannedAddresses(ConsumeSubNet(fuzzed_data_provider));
                 break;
             }
-            case 6: {
-                ban_man.Unban(ConsumeNetAddr(fuzzed_data_provider));
-                break;
-            }
             case 7: {
                 ban_man.Unban(ConsumeSubNet(fuzzed_data_provider));
                 break;


### PR DESCRIPTION
Initially motivated by: https://github.com/bitcoin/bitcoin/pull/19219/files#r442410269

### Issue
Minor change to `setban`: Prior to this PR, setban implementation behaves inconsistently. If the user bans 127.0.0.0/24, they are consequently unable to ban 127.0.0.0 but are able to ban 127.0.0.0/32.

i.e. the test shown here passes:

```cpp
BOOST_AUTO_TEST_CASE(rpc_ban_inconsistent)
{
    BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
    BOOST_CHECK_NO_THROW(CallRPC(std::string("setban 127.0.0.0/24 add")));
    BOOST_CHECK_THROW(CallRPC(std::string("setban 127.0.0.0 add")), std::runtime_error);
    BOOST_CHECK_NO_THROW(CallRPC(std::string("setban 127.0.0.0/32 add")));
}
```

### Root cause
- `BanMan::IsBanned(CNetAddr& ip)` returns true if `ip` is _a member of_ any banned subnet in `BanMan::m_banned`
- `BanMan::IsBanned(CSubNet& subnet)` returns true if `subnet` is _an exact match with_ any banned subnet in `BanMan::m_banned` (as opposed to a subset subnet which would be consistent with the overloaded implementation)
- `setban` implementation in `src/rpc/net.cpp` rejects the `setban` request if `BanMan::IsBanned` returns true

### Fix
This PR has two objectives:
1. Make the aforementioned inconsistent behavior, consistent.
2. It's probably not technically correct to just reject any bans. There's no such thing as an "invalid" ban request (except for the obvious invalid, or malformed addresses, etc). This PR proposes the following:

Let `(s0, t0)` be an existing ban, where `s0` is a subnet and `t0` is the ban expiration time. The user is now trying to add another ban `(s1, t1)`.

**Case s1 ⊂ s0:**
If `t1 <= t0`: do nothing, return success because the end goal is accomplished - this will minimize client error handling
If `t1 > t0`: insert `(s1, t1)` into `BanMan`

**Case s1 ⊇ s0:**
If `t1 <= t0`: insert `(s1, t1)` into `BanMan`
If `t1 > t0`: remove `(s0, t0)`, add `(s1, t1)` into `BanMan` (this consolidation reduces overhead when checking if a peer is banned)

**Case no overlap:**
insert `(s1, t1)` into `BanMan`

**Unban**:
Unbanning will look for exact matches of ban entries and remove them.
