### PR TITLE
add transport protocol field to peers listing in gui

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -682,6 +682,11 @@ QString NetworkToQString(Network net)
     assert(false);
 }
 
+QString TransportProtocolToQString(TransportProtocolType protocolType)
+{
+    return QString::fromStdString(TransportTypeAsString(protocolType));
+}
+
 QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction)
 {
     QString prefix;

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -225,6 +225,9 @@ namespace GUIUtil
     /** Convert enum Network to QString */
     QString NetworkToQString(Network net);
 
+    /** Convert enum TransportProtocolType to QString */
+    QString TransportProtocolToQString(TransportProtocolType protocolType);
+
     /** Convert enum ConnectionType to QString */
     QString ConnectionTypeToQString(ConnectionType conn_type, bool prepend_direction);
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -90,6 +90,8 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
             return GUIUtil::formatBytes(rec->nodeStats.nRecvBytes);
         case Subversion:
             return QString::fromStdString(rec->nodeStats.cleanSubVer);
+        case TransportProtocolType:
+            return GUIUtil::TransportProtocolToQString(rec->nodeStats.m_transport_type);
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     } else if (role == Qt::TextAlignmentRole) {
@@ -109,6 +111,8 @@ QVariant PeerTableModel::data(const QModelIndex& index, int role) const
             return QVariant(Qt::AlignRight | Qt::AlignVCenter);
         case Subversion:
             return {};
+        case TransportProtocolType:
+            return QVariant(Qt::AlignCenter);
         } // no default case, so the compiler can warn about missing cases
         assert(false);
     } else if (role == StatsRole) {

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -55,7 +55,8 @@ public:
         Ping,
         Sent,
         Received,
-        Subversion
+        Subversion,
+        TransportProtocolType
     };
 
     enum {
@@ -109,7 +110,10 @@ private:
         tr("Received"),
         /*: Title of Peers Table column which contains the peer's
             User Agent string. */
-        tr("User Agent")};
+        tr("User Agent"),
+        /*: Title of Peers Table column which contains the peer's
+            Transport Protocol version. */
+        tr("Transport")};
     QTimer *timer;
 };
 

--- a/src/qt/peertablesortproxy.cpp
+++ b/src/qt/peertablesortproxy.cpp
@@ -42,6 +42,8 @@ bool PeerTableSortProxy::lessThan(const QModelIndex& left_index, const QModelInd
         return left_stats.nRecvBytes < right_stats.nRecvBytes;
     case PeerTableModel::Subversion:
         return left_stats.cleanSubVer.compare(right_stats.cleanSubVer) < 0;
+    case PeerTableModel::TransportProtocolType:
+        return left_stats.m_transport_type < right_stats.m_transport_type;
     } // no default case, so the compiler can warn about missing cases
     assert(false);
 }


### PR DESCRIPTION
Added a field for Transport Protocol into the GUI, in the Peers modal. Now users will be able to see which of their peer connections are using v2 vs v1 transport. Right now the values are the literal strings v1 or v2. I thought v2 would be a more durable label than bip324 or something.

PR'd against your fork instead of the upstream gui repo since this change makes zero sense unless bip324 goes in.

If you'd rather keep GUI stuff out of your PR, feel free to close this and I'll cut it against the GUI repo once this goes in. 

screenshot: 
<img width="981" alt="image" src="https://user-images.githubusercontent.com/115941166/199637554-94f182c3-0aa7-43c4-8c7f-2379ce184035.png">
